### PR TITLE
曜日指定に対応

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -17,11 +17,22 @@ type CronJob struct {
 }
 
 func (job *CronJob) match(cond time.Time) (bool, *CronJob) {
-	// TODO 曜日の対応が別途必要
+	// 月をintに変換
 	monthInt, _ := strconv.Atoi(cond.Format("1"))
+
+	// 曜日をintに変換
+	weekday := cond.Format("Mon")
+	weekdayInt := weekDayMap[weekday]
+	weekDayMatch := contains(weekdayInt, job.dayOfWeek) || weekday == "Sun"
+	if !weekDayMatch && weekday == "Sun" {
+		// 日曜日は7の場合もある
+		weekdayInt = 7
+		weekDayMatch = contains(weekdayInt, job.dayOfWeek)
+	}
+
 	if contains(monthInt, job.month) &&
 		contains(cond.Hour(), job.hour) &&
-		contains(cond.Day(), job.dayOfMonth) &&
+		(contains(cond.Day(), job.dayOfMonth) || weekDayMatch) &&
 		contains(cond.Minute(), job.minute) {
 
 		return true, job
@@ -39,6 +50,7 @@ func contains(num int, slice []int) bool {
 	return false
 }
 
+// dayOfWeekMap はcrontabの曜日をintに変換する用
 var dayOfWeekMap = map[string]int{
 	"sun": 0,
 	"mon": 1,
@@ -49,13 +61,13 @@ var dayOfWeekMap = map[string]int{
 	"sat": 6,
 }
 
-// var dayOfWeekMap = map[int]string{
-// 	0: "sun",
-// 	1: "mon",
-// 	2: "tue",
-// 	3: "wed",
-// 	4: "thu",
-// 	5: "fri",
-// 	6: "sat",
-// 	7: "sun",
-// }
+// weekDayMap はtime.Dateの曜日をintに変換する用
+var weekDayMap = map[string]int{
+	"Sun": 0,
+	"Mon": 1,
+	"Tue": 2,
+	"Wed": 3,
+	"Thu": 4,
+	"Fri": 5,
+	"Sat": 6,
+}

--- a/cron.go
+++ b/cron.go
@@ -38,3 +38,24 @@ func contains(num int, slice []int) bool {
 	}
 	return false
 }
+
+var dayOfWeekMap = map[string]int{
+	"sun": 0,
+	"mon": 1,
+	"tue": 2,
+	"wed": 3,
+	"thu": 4,
+	"fri": 5,
+	"sat": 6,
+}
+
+// var dayOfWeekMap = map[int]string{
+// 	0: "sun",
+// 	1: "mon",
+// 	2: "tue",
+// 	3: "wed",
+// 	4: "thu",
+// 	5: "fri",
+// 	6: "sat",
+// 	7: "sun",
+// }

--- a/cron_test.go
+++ b/cron_test.go
@@ -10,8 +10,31 @@ func TestMatch(t *testing.T) {
 	jobs := []CronJob{
 		Parse("15 18 * * * /tmp/hoge.sh"),
 		Parse("*/5 * * * * /tmp/hoge.sh"),
+		Parse("* * 4 * thu /tmp/hoge.sh"),
+		Parse("* * 5 * wed /tmp/hoge.sh"),
 	}
 	condition := time.Date(2017, 10, 4, 18, 15, 0, 0, time.UTC)
+
+	for _, expected := range jobs {
+		contains, actual := expected.match(condition)
+		if !contains {
+			t.Fatalf("This job should be match: %+v \n", expected)
+		}
+		if !reflect.DeepEqual(&expected, actual) {
+			t.Fatalf("expected: %+v but actual: %+v\n", expected, actual)
+		}
+	}
+}
+
+func TestMatch_sunday(t *testing.T) {
+	jobs := []CronJob{
+		Parse("* * 1 * sun /tmp/hoge.sh"),
+		Parse("* * 1 * 0 /tmp/hoge.sh"),
+		Parse("* * 1 * 7 /tmp/hoge.sh"),
+		Parse("* * 1 * fri-sun /tmp/hoge.sh"),
+		Parse("* * 1 * 5,7 /tmp/hoge.sh"),
+	}
+	condition := time.Date(2017, 10, 8, 18, 15, 0, 0, time.UTC)
 
 	for _, expected := range jobs {
 		contains, actual := expected.match(condition)
@@ -27,6 +50,7 @@ func TestMatch(t *testing.T) {
 func TestUnMatch(t *testing.T) {
 	jobs := []CronJob{
 		Parse("1 19 4 10 * /tmp/hoge.sh"),
+		Parse("* * 3 * thu /tmp/hoge.sh"),
 	}
 	condition := time.Date(2017, 10, 4, 19, 0, 0, 0, time.UTC)
 

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 	app.Name = "rubusy"
 	app.Usage = "tell you which cron will be executed."
 	app.Action = func(c *cli.Context) error {
+		// TODO validation的なこと
 		fileName := c.Args().Get(0)
 		timeCondition := newTargetTime(time.Now())
 		fmt.Println(timeCondition)

--- a/parser.go
+++ b/parser.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -21,7 +22,9 @@ func Parse(job string) CronJob {
 	monthBlock := splited[3]
 	dayOfWeekBlock := splited[4]
 
-	// TODO 曜日は文字列表現の場合がある mon,tue,etc..
+	// 曜日は文字列表現の場合がある mon,tue,etc..
+	// 範囲指定の日曜終わりは順序が崩壊するので、先に最大値として処理する
+	dayOfWeekBlock = strings.Replace(dayOfWeekBlock, "-sun", "-7", 1)
 	for s, i := range dayOfWeekMap {
 		dayOfWeekBlock = strings.Replace(dayOfWeekBlock, s, fmt.Sprint(i), -1)
 	}
@@ -76,6 +79,10 @@ func parseBlock(block string, maxRange cronRange) []int {
 		splited := strings.Split(block, "-")
 		start, _ := strconv.Atoi(splited[0])
 		end, _ := strconv.Atoi(splited[1])
+		// FIXME toよりfromの方が大きいとエラーになる。。cronとしての書式チェックまで用意しないとだめ？
+		if start > end {
+			panic(errors.New("exists illegal format crontab"))
+		}
 		blockRange = newCronRange(start, end).all
 
 	} else {

--- a/parser.go
+++ b/parser.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -21,6 +22,9 @@ func Parse(job string) CronJob {
 	dayOfWeekBlock := splited[4]
 
 	// TODO 曜日は文字列表現の場合がある mon,tue,etc..
+	for s, i := range dayOfWeekMap {
+		dayOfWeekBlock = strings.Replace(dayOfWeekBlock, s, fmt.Sprint(i), -1)
+	}
 
 	return CronJob{
 		minute:     parseBlock(minuteBlock, minutesRange),

--- a/parser_test.go
+++ b/parser_test.go
@@ -11,6 +11,10 @@ func TestParse(t *testing.T) {
 		{line: "3-6 12-14 3-5 10-12 2-4 /tmp/hoge.sh", minute: []int{3, 4, 5, 6}, hour: []int{12, 13, 14}, dayOfMonth: []int{3, 4, 5}, month: []int{10, 11, 12}, dayOfWeek: []int{2, 3, 4}},
 		{line: "3-6/2 17-20/2 3-5/2 10-12/2 1-3/2 /tmp/hoge.sh", minute: []int{3, 5}, hour: []int{17, 19}, dayOfMonth: []int{3, 5}, month: []int{10, 12}, dayOfWeek: []int{1, 3}},
 		{line: "3-6/2 17-20/2 3-5/2 10-12/2 0/3 /tmp/hoge.sh", minute: []int{3, 5}, hour: []int{17, 19}, dayOfMonth: []int{3, 5}, month: []int{10, 12}, dayOfWeek: []int{0, 3, 6}},
+		{line: "* * * * tue /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{2}},
+		// {line: "* * * * sun-sat /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: dayOfWeekRange.all},
+		// {line: "* * * * mon,wed,thu /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{1, 3, 4}},
+		// {line: "* * * * fri-sun /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{5, 6, 7}},
 	}
 
 	for _, expected := range jobs {

--- a/parser_test.go
+++ b/parser_test.go
@@ -12,7 +12,7 @@ func TestParse(t *testing.T) {
 		{line: "3-6/2 17-20/2 3-5/2 10-12/2 1-3/2 /tmp/hoge.sh", minute: []int{3, 5}, hour: []int{17, 19}, dayOfMonth: []int{3, 5}, month: []int{10, 12}, dayOfWeek: []int{1, 3}},
 		{line: "3-6/2 17-20/2 3-5/2 10-12/2 0/3 /tmp/hoge.sh", minute: []int{3, 5}, hour: []int{17, 19}, dayOfMonth: []int{3, 5}, month: []int{10, 12}, dayOfWeek: []int{0, 3, 6}},
 		{line: "* * * * tue /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{2}},
-		// {line: "* * * * sun-sat /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: dayOfWeekRange.all},
+		{line: "* * * * sun-sat /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{0, 1, 2, 3, 4, 5, 6}},
 		// {line: "* * * * mon,wed,thu /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{1, 3, 4}},
 		// {line: "* * * * fri-sun /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{5, 6, 7}},
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -13,7 +13,7 @@ func TestParse(t *testing.T) {
 		{line: "3-6/2 17-20/2 3-5/2 10-12/2 0/3 /tmp/hoge.sh", minute: []int{3, 5}, hour: []int{17, 19}, dayOfMonth: []int{3, 5}, month: []int{10, 12}, dayOfWeek: []int{0, 3, 6}},
 		{line: "* * * * tue /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{2}},
 		{line: "* * * * sun-sat /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{0, 1, 2, 3, 4, 5, 6}},
-		// {line: "* * * * mon,wed,thu /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{1, 3, 4}},
+		{line: "* * * * mon,wed,thu /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{1, 3, 4}},
 		// {line: "* * * * fri-sun /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{5, 6, 7}},
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -14,7 +14,7 @@ func TestParse(t *testing.T) {
 		{line: "* * * * tue /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{2}},
 		{line: "* * * * sun-sat /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{0, 1, 2, 3, 4, 5, 6}},
 		{line: "* * * * mon,wed,thu /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{1, 3, 4}},
-		// {line: "* * * * fri-sun /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{5, 6, 7}},
+		{line: "* * * * fri-sun /tmp/hoge.sh", minute: minutesRange.all, hour: hourRange.all, dayOfMonth: dayOfMonthRange.all, month: monthRange.all, dayOfWeek: []int{5, 6, 7}},
 	}
 
 	for _, expected := range jobs {


### PR DESCRIPTION
特記事項

- crontabでは0もしくは7を日曜として扱う
- 「日」および「曜日」（第5フィールド）が同時に指定された場合、どちらかが満たされた場合両方でコマンドが実行される