### PR TITLE
fix help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # rubusy
+
+rubusy is cron job schedule searcher which tell you when it scheduled.
+
+## Usage
+
+```
+$ rubusy crontab.txt
+from: 2017/10/17 18:35 - to: 2018/10/17 18:35
+==============================================
+2017/10/18 09:15 : 15 9 * * * /tmp/hoge1.sh
+2017/10/17 20:10 : 10 20 * * * /tmp/fuga1.sh
+2017/12/01 10:10 : 10 10 * 12 * /tmp/fuga2.sh
+2017/10/17 18:35 : * * * * * /tmp/fuga3.sh
+2018/10/03 10:00 : * 10 3 10 * /tmp/fuga4.sh
+2017/10/24 06:15 : 15 6 24 * * /tmp/piyo.sh
+```

--- a/main.go
+++ b/main.go
@@ -13,21 +13,21 @@ import (
 func main() {
 	app := cli.NewApp()
 	app.Name = "rubusy"
-	app.Usage = "tell you which cron will be executed."
-	//app.UsageText = "hogefugapiyo"
+	app.Usage = "cron job schedule searcher"
+	app.UsageText = "rubusy [-l line] [-fr from] [-p] [--line value] [--from value] [--plain] [file]"
 	app.Version = "0.0.1"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:  "line, l",
-			Usage: "crontab one line",
+			Name:  "job, j",
+			Usage: "specific job search of the input.",
 		},
 		cli.StringFlag{
 			Name:  "from, fr",
-			Usage: "crontab schedule search. format should be 2006-01-02-15-04",
+			Usage: "specific schedule search from time formatted like 2006-01-02-15-04",
 		},
 		cli.BoolFlag{
-			Name:  "plain,p",
-			Usage: "disable header",
+			Name:  "plain, p",
+			Usage: "only result is written to standard output.",
 		},
 	}
 	app.Action = func(c *cli.Context) error {


### PR DESCRIPTION
こんな感じにした

```
$ rubusy --help
NAME:
   rubusy - cron job schedule searcher

USAGE:
   rubusy [-l line] [-fr from] [-p] [--line value] [--from value] [--plain] [file]

VERSION:
   0.0.1

COMMANDS:
     help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --line value, -l value    specific one line search of the input.
   --from value, --fr value  specific schedule search from time formatted like 2006-01-02-15-04
   --plain, -p               only result is written to standard output.
   --help, -h                show help
   --version, -v             print the version
```